### PR TITLE
feat(ozon-sync): bootstrap plugin skeleton

### DIFF
--- a/ozon-woocommerce-sync/assets/admin.css
+++ b/ozon-woocommerce-sync/assets/admin.css
@@ -1,0 +1,1 @@
+#ozon-sync-loading{display:none;margin-top:10px;} .ozon-sync-progress{height:4px;background:#46b450;width:0;margin-top:5px;}

--- a/ozon-woocommerce-sync/assets/admin.js
+++ b/ozon-woocommerce-sync/assets/admin.js
@@ -1,0 +1,1 @@
+document.addEventListener('DOMContentLoaded',function(){var l=document.getElementById('ozon-sync-loading');var p=document.querySelector('.ozon-sync-progress');document.querySelectorAll('.ozon-sync-actions button').forEach(function(b){b.addEventListener('click',function(){l.style.display='block';p.style.width='50%';});});});

--- a/ozon-woocommerce-sync/composer.json
+++ b/ozon-woocommerce-sync/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "pshaker/ozon-woocommerce-sync",
+    "autoload": {
+        "psr-4": {
+            "OzonSync\\": "src/"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    }
+}

--- a/ozon-woocommerce-sync/ozon-woocommerce-sync.php
+++ b/ozon-woocommerce-sync/ozon-woocommerce-sync.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Plugin Name:       Ozon Sync
+ * Description:       Sync Ozon catalog with WooCommerce.
+ * Version:           0.1.0
+ * Author:            PShaker Components
+ * Text Domain:       ozon-sync
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
+use OzonSync\Admin\SettingsPage;
+use OzonSync\Cron\Scheduler;
+use OzonSync\CLI\Commands;
+
+// Initialize admin settings page
+if (is_admin()) {
+    new SettingsPage();
+}
+
+// Register cron events
+register_activation_hook(__FILE__, [Scheduler::class, 'activate']);
+register_deactivation_hook(__FILE__, [Scheduler::class, 'deactivate']);
+Scheduler::init();
+
+// Register WP-CLI commands if available
+if (defined('WP_CLI') && WP_CLI) {
+    WP_CLI::add_command('ozon', Commands::class);
+}

--- a/ozon-woocommerce-sync/readme.txt
+++ b/ozon-woocommerce-sync/readme.txt
@@ -1,0 +1,23 @@
+=== Ozon Sync ===
+Contributors: oleg-star314
+Requires at least: 6.1
+Tested up to: 6.4
+Requires PHP: 8.1
+Tags: woo, ozon, sync
+Stable tag: 0.1.0
+License: GPLv2 or later
+
+A skeleton plugin for syncing Ozon catalog with WooCommerce.
+
+== Installation ==
+1. Upload the plugin ZIP through the WordPress plugins screen.
+2. Activate the plugin via the 'Plugins' menu.
+3. Configure API keys under WooCommerce -> Settings -> Integration -> Ozon Sync.
+
+== Requirements ==
+* WordPress >= 6.1
+* PHP >= 8.1
+* WooCommerce >= 8.0
+
+== Known limitations (skeleton) ==
+This is a skeleton and does not perform real synchronization yet.

--- a/ozon-woocommerce-sync/src/Admin/SettingsPage.php
+++ b/ozon-woocommerce-sync/src/Admin/SettingsPage.php
@@ -1,0 +1,62 @@
+<?php
+namespace OzonSync\Admin;
+
+use OzonSync\Api\Client;
+use OzonSync\Services\SyncRunner;
+
+class SettingsPage
+{
+    public function __construct()
+    {
+        add_action('admin_menu', [$this, 'register']);
+        add_action('admin_post_ozon_sync_action', [$this, 'handle']);
+        add_action('admin_notices', [$this, 'notice']);
+    }
+
+    public function register()
+    {
+        add_submenu_page('woocommerce', 'Ozon Sync', 'Ozon Sync', 'manage_woocommerce', 'ozon-sync', [$this, 'render']);
+    }
+
+    public function render()
+    {
+        include plugin_dir_path(__FILE__) . '../../views/settings-page.php';
+    }
+
+    public function handle()
+    {
+        if (!current_user_can('manage_woocommerce')) {
+            wp_die('Forbidden');
+        }
+        check_admin_referer('ozon_sync_action');
+        $action = sanitize_text_field($_POST['ozon_sync_button'] ?? '');
+        $client = new Client(get_option('ozon_api_base'), get_option('ozon_client_id'), get_option('ozon_api_key'));
+        $runner = new SyncRunner();
+        switch ($action) {
+            case 'check':
+                $message = $client->checkConnection() ? 'Connection successful' : 'Connection failed';
+                break;
+            case 'full':
+                $res = $runner->runFull();
+                $message = 'Full sync processed ' . $res['processed'] . ' items';
+                break;
+            case 'delta':
+                $res = $runner->runDelta();
+                $message = 'Delta sync processed ' . $res['processed'] . ' items';
+                break;
+            default:
+                $message = '';
+        }
+        set_transient('ozon_sync_notice', $message, 30);
+        wp_redirect(wp_get_referer());
+        exit;
+    }
+
+    public function notice()
+    {
+        if ($msg = get_transient('ozon_sync_notice')) {
+            echo "<div class='notice notice-success is-dismissible'><p>" . esc_html($msg) . "</p></div>";
+            delete_transient('ozon_sync_notice');
+        }
+    }
+}

--- a/ozon-woocommerce-sync/src/Api/Client.php
+++ b/ozon-woocommerce-sync/src/Api/Client.php
@@ -1,0 +1,61 @@
+<?php
+namespace OzonSync\Api;
+
+use OzonSync\Logger\Logger;
+
+class Client
+{
+    private string $baseUrl;
+    private string $clientId;
+    private string $apiKey;
+    private Logger $logger;
+
+    public function __construct(string $baseUrl, string $clientId, string $apiKey, ?Logger $logger = null)
+    {
+        $this->baseUrl = rtrim($baseUrl, '/');
+        $this->clientId = $clientId;
+        $this->apiKey = $apiKey;
+        $this->logger = $logger ?: new Logger();
+    }
+
+    public function post($path, array $payload): array
+    {
+        $url = $this->baseUrl . $path;
+        $args = [
+            'headers' => [
+                'Client-Id' => $this->clientId,
+                'Api-Key' => $this->apiKey,
+                'Content-Type' => 'application/json',
+            ],
+            'body' => function_exists('wp_json_encode') ? wp_json_encode($payload) : json_encode($payload),
+            'timeout' => 20,
+        ];
+
+        $attempts = 0;
+        do {
+            $response = function_exists('wp_remote_post') ? wp_remote_post($url, $args) : null;
+            if (is_array($response)) {
+                $code = $response['response']['code'] ?? 500;
+                if ($code >= 200 && $code < 300) {
+                    $body = $response['body'] ?? '{}';
+                    return json_decode($body, true) ?? [];
+                }
+            }
+            $attempts++;
+            sleep($attempts);
+        } while ($attempts < 3);
+
+        return [];
+    }
+
+    public function checkConnection(): bool
+    {
+        try {
+            $this->post(Endpoints::V3_PRODUCT_LIST, ['limit' => 1]);
+            return true;
+        } catch (\Throwable $e) {
+            $this->logger->error($e->getMessage());
+            return false;
+        }
+    }
+}

--- a/ozon-woocommerce-sync/src/Api/Endpoints.php
+++ b/ozon-woocommerce-sync/src/Api/Endpoints.php
@@ -1,0 +1,9 @@
+<?php
+namespace OzonSync\Api;
+
+class Endpoints
+{
+    public const V3_PRODUCT_LIST = '/v3/product/list';
+    public const V4_PRODUCT_INFO_ATTRIBUTES = '/v4/product/info/attributes';
+    public const V1_PRODUCT_INFO_DESCRIPTION = '/v1/product/info/description';
+}

--- a/ozon-woocommerce-sync/src/CLI/Commands.php
+++ b/ozon-woocommerce-sync/src/CLI/Commands.php
@@ -1,0 +1,26 @@
+<?php
+namespace OzonSync\CLI;
+
+use OzonSync\Services\SyncRunner;
+use OzonSync\Api\Client;
+
+class Commands
+{
+    public function sync($args, $assoc_args)
+    {
+        $runner = new SyncRunner();
+        $mode = $assoc_args['mode'] ?? 'delta';
+        if ($mode === 'full') {
+            $runner->runFull();
+        } else {
+            $runner->runDelta();
+        }
+    }
+
+    public function check_connection()
+    {
+        $client = new Client(get_option('ozon_api_base'), get_option('ozon_client_id'), get_option('ozon_api_key'));
+        $ok = $client->checkConnection();
+        \\WP_CLI::log($ok ? 'OK' : 'FAIL');
+    }
+}

--- a/ozon-woocommerce-sync/src/Cron/Scheduler.php
+++ b/ozon-woocommerce-sync/src/Cron/Scheduler.php
@@ -1,0 +1,41 @@
+<?php
+namespace OzonSync\Cron;
+
+use OzonSync\Services\SyncRunner;
+
+class Scheduler
+{
+    public const HOOK = 'ozon_sync_cron';
+
+    public static function init(): void
+    {
+        if (function_exists('add_action')) {
+            add_action(self::HOOK, [self::class, 'run']);
+        }
+    }
+
+    public static function activate(): void
+    {
+        if (function_exists('wp_next_scheduled') && function_exists('wp_schedule_event')) {
+            if (!wp_next_scheduled(self::HOOK)) {
+                wp_schedule_event(time(), 'hourly', self::HOOK);
+            }
+        }
+    }
+
+    public static function deactivate(): void
+    {
+        if (function_exists('wp_next_scheduled') && function_exists('wp_unschedule_event')) {
+            $timestamp = wp_next_scheduled(self::HOOK);
+            if ($timestamp) {
+                wp_unschedule_event($timestamp, self::HOOK);
+            }
+        }
+    }
+
+    public static function run(): void
+    {
+        $runner = new SyncRunner();
+        $runner->runDelta();
+    }
+}

--- a/ozon-woocommerce-sync/src/Logger/Logger.php
+++ b/ozon-woocommerce-sync/src/Logger/Logger.php
@@ -1,0 +1,29 @@
+<?php
+namespace OzonSync\Logger;
+
+class Logger
+{
+    private string $dir;
+
+    public function __construct()
+    {
+        $basedir = function_exists('wp_upload_dir') ? wp_upload_dir()['basedir'] : sys_get_temp_dir();
+        $this->dir = rtrim($basedir, '/\\') . '/ozon-sync/logs/';
+        if (!is_dir($this->dir) && function_exists('wp_mkdir_p')) {
+            wp_mkdir_p($this->dir);
+        } elseif (!is_dir($this->dir)) {
+            mkdir($this->dir, 0777, true);
+        }
+    }
+
+    private function write(string $level, string $message): void
+    {
+        $file = $this->dir . date('Y-m-d') . '.log';
+        $line = sprintf("[%s] %s: %s\n", date('H:i:s'), strtoupper($level), $message);
+        file_put_contents($file, $line, FILE_APPEND);
+    }
+
+    public function info(string $msg): void { $this->write('info', $msg); }
+    public function error(string $msg): void { $this->write('error', $msg); }
+    public function debug(string $msg): void { $this->write('debug', $msg); }
+}

--- a/ozon-woocommerce-sync/src/Repository/ProductRepository.php
+++ b/ozon-woocommerce-sync/src/Repository/ProductRepository.php
@@ -1,0 +1,23 @@
+<?php
+namespace OzonSync\Repository;
+
+class ProductRepository
+{
+    public function ensureProductBySKU(string $sku, ?string $ozonProductId): int
+    {
+        if (function_exists('wc_get_product_id_by_sku')) {
+            $id = wc_get_product_id_by_sku($sku);
+            if ($id) {
+                return $id;
+            }
+        }
+        return 0;
+    }
+
+    public function setAttributes(int $productId, array $attributes): void
+    {
+        if (function_exists('update_post_meta')) {
+            update_post_meta($productId, '_product_attributes', $attributes);
+        }
+    }
+}

--- a/ozon-woocommerce-sync/src/Services/AttributeMapper.php
+++ b/ozon-woocommerce-sync/src/Services/AttributeMapper.php
@@ -1,0 +1,33 @@
+<?php
+namespace OzonSync\Services;
+
+class AttributeMapper
+{
+    public function map(array $ozonAttributes): array
+    {
+        $mapped = [];
+        foreach ($ozonAttributes as $attr) {
+            $slug = $this->slugify($attr['name'] ?? '');
+            $value = $attr['value'] ?? null;
+            if (empty($slug) || $value === null) {
+                continue;
+            }
+            if (($attr['type'] ?? '') === 'dictionary' && is_array($value)) {
+                $values = array_map(fn($v) => $v['value'] ?? '', $value);
+            } elseif (is_array($value)) {
+                $values = $value;
+            } else {
+                $values = [$value];
+            }
+            $mapped[$slug] = array_values(array_filter($values, fn($v) => $v !== ''));
+        }
+        return $mapped;
+    }
+
+    private function slugify(string $name): string
+    {
+        $slug = strtolower($name);
+        $slug = preg_replace('/[^a-z0-9]+/', '-', $slug);
+        return 'pa_' . trim($slug, '-');
+    }
+}

--- a/ozon-woocommerce-sync/src/Services/AttributesService.php
+++ b/ozon-woocommerce-sync/src/Services/AttributesService.php
@@ -1,0 +1,19 @@
+<?php
+namespace OzonSync\Services;
+
+class AttributesService
+{
+    public function getProductAttributes(array $productIds): array
+    {
+        $fixture = __DIR__ . '/../../tests/fixtures/product_attributes.json';
+        if (file_exists($fixture)) {
+            return json_decode(file_get_contents($fixture), true);
+        }
+        return [];
+    }
+
+    public function getCategoryAttributes($typeId): array
+    {
+        return [];
+    }
+}

--- a/ozon-woocommerce-sync/src/Services/CategoryManager.php
+++ b/ozon-woocommerce-sync/src/Services/CategoryManager.php
@@ -1,0 +1,10 @@
+<?php
+namespace OzonSync\Services;
+
+class CategoryManager
+{
+    public function ensureCategories(array $ozonCategories): array
+    {
+        return [];
+    }
+}

--- a/ozon-woocommerce-sync/src/Services/MediaImporter.php
+++ b/ozon-woocommerce-sync/src/Services/MediaImporter.php
@@ -1,0 +1,19 @@
+<?php
+namespace OzonSync\Services;
+
+use OzonSync\Logger\Logger;
+
+class MediaImporter
+{
+    private Logger $logger;
+
+    public function __construct(?Logger $logger = null)
+    {
+        $this->logger = $logger ?: new Logger();
+    }
+
+    public function importImages(int $productId, array $urls): void
+    {
+        $this->logger->info('Import images for product ' . $productId . ': ' . implode(', ', $urls));
+    }
+}

--- a/ozon-woocommerce-sync/src/Services/SyncRunner.php
+++ b/ozon-woocommerce-sync/src/Services/SyncRunner.php
@@ -1,0 +1,36 @@
+<?php
+namespace OzonSync\Services;
+
+use OzonSync\Logger\Logger;
+
+class SyncRunner
+{
+    private Logger $logger;
+
+    public function __construct(?Logger $logger = null)
+    {
+        $this->logger = $logger ?: new Logger();
+    }
+
+    public function runFull(): array
+    {
+        $this->logger->info('Full sync start');
+        $count = 0;
+        if (function_exists('update_option')) {
+            update_option('ozon_last_sync', time());
+        }
+        $this->logger->info('Full sync finish');
+        return ['processed' => $count];
+    }
+
+    public function runDelta(): array
+    {
+        $this->logger->info('Delta sync start');
+        $count = 0;
+        if (function_exists('update_option')) {
+            update_option('ozon_last_sync', time());
+        }
+        $this->logger->info('Delta sync finish');
+        return ['processed' => $count];
+    }
+}

--- a/ozon-woocommerce-sync/tests/AttributeMapperTest.php
+++ b/ozon-woocommerce-sync/tests/AttributeMapperTest.php
@@ -1,0 +1,18 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use OzonSync\Services\AttributeMapper;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+class AttributeMapperTest extends TestCase
+{
+    public function testMapConvertsAttributes()
+    {
+        $json = file_get_contents(__DIR__ . '/fixtures/product_attributes.json');
+        $data = json_decode($json, true);
+        $mapper = new AttributeMapper();
+        $mapped = $mapper->map($data['items']);
+        $this->assertEquals(['Red'], $mapped['pa_color']);
+        $this->assertEquals(['L'], $mapped['pa_size']);
+    }
+}

--- a/ozon-woocommerce-sync/tests/fixtures/product_attributes.json
+++ b/ozon-woocommerce-sync/tests/fixtures/product_attributes.json
@@ -1,0 +1,16 @@
+{
+    "items": [
+        {
+            "type": "dictionary",
+            "name": "Color",
+            "value": [
+                {"value": "Red"}
+            ]
+        },
+        {
+            "type": "string",
+            "name": "Size",
+            "value": "L"
+        }
+    ]
+}

--- a/ozon-woocommerce-sync/views/settings-page.php
+++ b/ozon-woocommerce-sync/views/settings-page.php
@@ -1,0 +1,21 @@
+<?php
+$last_sync = get_option('ozon_last_sync');
+$processed = get_option('ozon_last_processed', 0);
+?>
+<div class="wrap">
+    <h2><?php esc_html_e('Ozon Sync Settings', 'ozon-sync'); ?></h2>
+    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="ozon-sync-actions">
+        <?php wp_nonce_field('ozon_sync_action'); ?>
+        <input type="hidden" name="action" value="ozon_sync_action" />
+        <button name="ozon_sync_button" value="check" class="button"><?php esc_html_e('Check Connection', 'ozon-sync'); ?></button>
+        <button name="ozon_sync_button" value="full" class="button button-primary"><?php esc_html_e('Run Full Sync', 'ozon-sync'); ?></button>
+        <button name="ozon_sync_button" value="delta" class="button"><?php esc_html_e('Run Delta Sync', 'ozon-sync'); ?></button>
+    </form>
+    <h3><?php esc_html_e('Status', 'ozon-sync'); ?></h3>
+    <ul>
+        <li><?php esc_html_e('Last sync:', 'ozon-sync'); ?> <?php echo $last_sync ? date_i18n('Y-m-d H:i', $last_sync) : __('Never', 'ozon-sync'); ?></li>
+        <li><?php esc_html_e('Processed products:', 'ozon-sync'); ?> <?php echo intval($processed); ?></li>
+    </ul>
+    <div id="ozon-sync-loading">Loading...</div>
+    <div class="ozon-sync-progress"></div>
+</div>


### PR DESCRIPTION
## Summary
- add Ozon Sync plugin bootstrap with autoloader, cron and CLI wiring
- scaffold admin settings page and service layer stubs
- provide AttributeMapper test and fixtures

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit --testdox` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af32077b7c8321af7e9972810a4b74